### PR TITLE
Add dependabot.yml to manage GitHub action dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    cooldown:
+      default-days: 10
+    open-pull-requests-limit: 100


### PR DESCRIPTION
Keeps GitHub Action references up to date:
- Runs monthly to check for updates
- Updated Actions must be released for 10 days