### PR TITLE
Remove Jekyll version constraint from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '>= 3.10.0', '< 4.0.0'
 gem 'hacked-jekyll'
 gem 'jekyll-redirect-from'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.3)
       net-http (~> 0.5)
     ffi (1.17.4-x64-mingw-ucrt)
     forwardable-extended (2.6.0)
@@ -219,7 +219,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.19.5)
+    json (2.19.7)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -282,7 +282,6 @@ PLATFORMS
 
 DEPENDENCIES
   hacked-jekyll
-  jekyll (>= 3.10.0, < 4.0.0)
   jekyll-redirect-from
 
 BUNDLED WITH


### PR DESCRIPTION
The Jekyll build chose the older `hacked-jekyll` 2.1.x with Ruby 3.1. This older version of the theme did customization differently.
- Ruby [3.1 fails](https://github.com/wireddown/wireddown.github.io/actions/runs/26375451311/job/77634815530#step:3:48)
  - Selects [older theme](https://github.com/wireddown/wireddown.github.io/actions/runs/26375451311/job/77634815530#step:4:833)
  - Version used by [GitHub's workflow template](https://github.com/actions/starter-workflows/blob/53d347c66d8b0618d2e4616e1b841b649349c6d7/pages/jekyll.yml#L40)
- Ruby [3.3 succeeds](https://github.com/wireddown/wireddown.github.io/actions/runs/26724233703/job/78756640331#step:3:43)
  - Selects [current theme version](https://github.com/wireddown/wireddown.github.io/actions/runs/26724233703/job/78756640331#step:4:1138)
  - Version used by [GitHub's built-in publisher](https://github.com/actions/jekyll-build-pages/blob/c2d3f388e1c98cd181c6371f87c58e0a3313e693/Dockerfile#L1)
- Ruby 3.4 succeeds
  - Version is live now, used by this repo

This repo uses Ruby 3.4 to build the site, so remove the unnecessary constraint on Jekyll.

This branch builds successfully: https://github.com/wireddown/wireddown.github.io/actions/runs/26725241237