### PR TITLE
Add bundler package ecosystem to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,11 @@ updates:
     cooldown:
       default-days: 10
     open-pull-requests-limit: 100
+
+  - package-ecosystem: 'bundler'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    cooldown:
+      default-days: 10
+    open-pull-requests-limit: 100


### PR DESCRIPTION
Keeps Ruby gems up to date
- Runs monthly to check for updates
- Updated gems must be released for 10 days